### PR TITLE
chore: update node version from 12 to 16

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ jobs:
         npm run build
 
     - name: Update package.json version
-      uses: jossef/action-set-json-field@v2
+      uses: jossef/action-set-json-field@v2.1
       with:
         file: package.json
         field: version

--- a/action.yml
+++ b/action.yml
@@ -16,7 +16,7 @@ inputs:
     default: ""
     description: "optional. if set to any non-empty value will parse the data in 'value' field to JSON"
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'dist/index.js'
 branding:
   icon: 'edit'


### PR DESCRIPTION
Since node 12 has been out of support since [April 2022](https://github.com/nodejs/Release/#end-of-life-releases) and is deprecated I have update node to version 16. Tests are passing locally.
Please create a new release `2.1`.
Thanks!

Fixes #6 
->
Node.js 12 actions are deprecated. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/. Please update the following actions to use Node.js 16: jossef/action-set-json-field